### PR TITLE
fix(scripts): rename `prettier` package script to `format`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prepare": "husky install",
-    "prettier": "prettier --write .",
+    "format": "prettier --write .",
     "lint": "eslint ."
   },
   "browserslist": {


### PR DESCRIPTION
The package script `prettier` is defined as `prettier --write .`. `yarn prettier` will run the package script `prettier`, which is not expected when using `yarn` to run the binary `prettier` manually.

For example, to format current directory recursively, use `yarn prettier --write .`. Without the package script `prettier`, this is, as expected, equivalent to:

```bash
./node_modules/.bin/prettier --write .
```

However, with the package script `prettier`, this becomes:

```bash
./node_modules/.bin/prettier --write . --write .
```

Rename the package `prettier` to `format` can solve this issue while keeping the original package scripts functionality.
